### PR TITLE
Fix NoteViewModel nullObject return type

### DIFF
--- a/lib/presentation/view_model/journal/note_view_model.dart
+++ b/lib/presentation/view_model/journal/note_view_model.dart
@@ -49,5 +49,6 @@ class NoteViewModel extends ChangeNotifier{
   factory NoteViewModel.createMonthlyGoalsViewModel(JournalRepository repository) => NoteViewModel(repository.updateMonthlyGoals, repository.fetchMonthlyGoals);
   factory NoteViewModel.createMonthlyEventsViewModel(JournalRepository repository) => NoteViewModel(repository.updateMonthlyEvents, repository.fetchMonthlyEvents);
 
-  factory NoteViewModel.nullObject() => NoteViewModel((v){}, (){return Future.value();});
+  factory NoteViewModel.nullObject() =>
+      NoteViewModel((v) {}, () => Future<List<String>?>.value(null));
 }


### PR DESCRIPTION
## Summary
- fix return type of `NoteViewModel.nullObject`

## Testing
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b9a590bd0832ab8aa106fa8a0bec3